### PR TITLE
lower_mac/viterbi: Fix uninitialized memory reads in libosmocore

### DIFF
--- a/src/lower_mac/viterbi_cch.c
+++ b/src/lower_mac/viterbi_cch.c
@@ -52,6 +52,7 @@ static const struct osmo_conv_code conv_cch = {
 	.K = 5,
 	.next_output = conv_cch_next_output,
 	.next_state  = conv_cch_next_state,
+	.term = CONV_TERM_TRUNCATION,
 };
 
 


### PR DESCRIPTION
Set term mode to CONV_TERM_TRUNCATION, which prevents libosmocore from
performing uninitialized memory reads leading to non-deterministic
decoding results.

Note: I was playing with some recorded data and noticed that the amount of CRC OK differs between runs. This patch seems to fix the issue. Not sure if it is a proper fix though.